### PR TITLE
feat(algorand/core): add rlp:- to HasProposalData

### DIFF
--- a/consensus/algorand/core/types.go
+++ b/consensus/algorand/core/types.go
@@ -265,7 +265,7 @@ type HasProposalData struct {
 	Round  uint32
 	Proof  ed25519.VrfProof
 	Value  common.Hash
-	Weight uint64
+	Weight uint64 `rlp:"-"`
 }
 
 func (data *HasProposalData) String() string {

--- a/core/types/certificate.go
+++ b/core/types/certificate.go
@@ -102,9 +102,6 @@ func LessThanByProof(proofA, proofB *ed25519.VrfProof, jA, jB uint64) bool {
 }
 
 func LessThanByProofInt(proofA, proofB *ed25519.VrfProof, jA, jB uint64) int {
-	if jA == 0 && jB == 0 {
-		panic(fmt.Sprintf("jA == 0 && jB == 0, it is impossible"))
-	}
 	if jA == 0 {
 		return 1
 	} else if jB == 0 {


### PR DESCRIPTION
add rlp:- flag to HasProposalData and remove panic when both weight were 0 in LessThanByProofInt. it can smooth upgrade from the previous version.